### PR TITLE
Allow Kotlin compiler server address to be set at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 ```
 
+You can also overwrite the server where the code will be sent to be compiled and analyzed (for example if you host a server instance that includes your own Kotlin libraries). For that you can set the `data-server` attibute, like this:
+
+```html
+<script src="https://unpkg.com/kotlin-playground@1" data-selector="code" data-server="https://my-kotlin-playground-server"></script>
+```
+
 ### Host your own instance
 
 Install Kotlin-playground as dependency via NPM.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
+You could also use the events, or overwrite the server this way by passing them as part of the function parameters:
+
+```js
+// ES6
+import playground from 'kotlin-playground';
+
+document.addEventListener('DOMContentLoaded', () => {
+  playground('code', eventFunctions, 'https://my-kotlin-playground-server'); // attach to all <code> elements
+});
+```
+
 ### Use from plugins
 
 1) [Kotlin Playground WordPress plugin](https://github.com/Kotlin/kotlin-playground-wp-plugin) — [WordPress](https://wordpress.com/) plugin which allows to embed interactive Kotlin playground to any post.

--- a/README.md
+++ b/README.md
@@ -62,14 +62,18 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-You could also use the events, or overwrite the server this way by passing them as part of the function parameters:
+You could also use the events, or overwrite the server this way by passing them as part of the function parameter `options`:
 
 ```js
 // ES6
 import playground from 'kotlin-playground';
 
 document.addEventListener('DOMContentLoaded', () => {
-  playground('code', eventFunctions, 'https://my-kotlin-playground-server'); // attach to all <code> elements
+  const options = {
+    eventFunctions: {},
+    server: 'https://my-kotlin-playground-server'
+  }
+  playground('code', options); // attach to all <code> elements
 });
 ```
 
@@ -80,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ### Events
 
-Kotlin Playground supports several events on additional parameter on initialisation;
+Kotlin Playground supports several events on additional parameter on initialisation.
 
 For example:
 ```js
@@ -98,7 +102,7 @@ const eventFunctions = {
   callback: callback(targetNode, mountNode)
 };
 
-playground('.selector', eventFunctions)
+playground('.selector', { eventFunctions })
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![official JetBrains project](http://jb.gg/badges/official-plastic.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![NPM version](https://img.shields.io/npm/v/kotlin-playground.svg)](https://www.npmjs.com/package/kotlin-playground) 
+[![NPM version](https://img.shields.io/npm/v/kotlin-playground.svg)](https://www.npmjs.com/package/kotlin-playground)
 
 # Kotlin Playground
 
@@ -62,29 +62,14 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-You could also use the events, or overwrite the server this way by passing them as part of the function parameter `options`:
-
-```js
-// ES6
-import playground from 'kotlin-playground';
-
-document.addEventListener('DOMContentLoaded', () => {
-  const options = {
-    eventFunctions: {},
-    server: 'https://my-kotlin-playground-server'
-  }
-  playground('code', options); // attach to all <code> elements
-});
-```
-
 ### Use from plugins
 
 1) [Kotlin Playground WordPress plugin](https://github.com/Kotlin/kotlin-playground-wp-plugin) — [WordPress](https://wordpress.com/) plugin which allows to embed interactive Kotlin playground to any post.
 2) [Kotlin Playground Coursera plugin](https://github.com/AlexanderPrendota/kotlin-playground-coursera-plugin) — Allows embedding interactive Kotlin playground for [coursera](https://www.coursera.org/) lessons.
 
-### Events
+### Options
 
-Kotlin Playground supports several events on additional parameter on initialisation.
+Kotlin Playground supports several events, and also server URL overwriting passing an additional `options` parameter on initialisation.
 
 For example:
 ```js
@@ -96,13 +81,14 @@ function onTestPassed() {
    console.log("Tests passed!");
 }
 
-const eventFunctions = {
+const options = {
+  server: 'https://my-kotlin-playground-server',
   onChange: onChange(code),
   onTestPassed: onTestPassed,
   callback: callback(targetNode, mountNode)
 };
 
-playground('.selector', { eventFunctions })
+playground('.selector', options)
 
 ```
 
@@ -121,7 +107,7 @@ playground('.selector', { eventFunctions })
 - `callback(targetNode, mountNode)` — Is called after playground's united.
  _targetNode_ — node with plain text before component initialization.
  _mountNode_  — new node with runnable editor.
- 
+
 - `getInstance(instance)` - Getting playground state API.
 
   ```js
@@ -155,7 +141,7 @@ Use the following attributes on elements that are converted to editors to adjust
   */
   </code>
   ```
-  
+
 - `data-target-platform`: target platform: `junit`, `canvas`, `js` or `java` (default).
 
   ```html
@@ -174,7 +160,7 @@ Use the following attributes on elements that are converted to editors to adjust
     */
   </code>
   ```
-  
+
   Or, you can make only a part of code read-only by placing it between `//sampleStart` and `//sampleEnd` markers.
   If you don't need this just use attribute `none-markers`.
   For adding hidden files: put files between `<textarea>` tag with class `hidden-dependency`.
@@ -182,7 +168,7 @@ Use the following attributes on elements that are converted to editors to adjust
   ```html
   <code>
   import cat.Cat
-  
+
   fun main(args: Array<String>) {
   //sampleStart
       val cat = Cat("Kitty")
@@ -191,22 +177,22 @@ Use the following attributes on elements that are converted to editors to adjust
   }
     <textarea class="hidden-dependency">
       package cat
-      class Cat(val name: String) 
+      class Cat(val name: String)
     </textarea>
   </code>
   ```
   Also if you want to hide code snippet just set the attribute `folded-button` to `false` value.
-  
+
 - `data-js-libs`: By default component loads jQuery and makes it available to the code running in the editor. If you need any additional JS libraries, specify them as comma-separated list in this attribute.
 
   ```html
-  <code data-js-libs="https://my-awesome-js-lib/lib.min.js"> 
+  <code data-js-libs="https://my-awesome-js-lib/lib.min.js">
     /*
     Your code here
     */
    </code>
   ```
-  
+
 - `auto-indent="true|false"`: Whether to use the context-sensitive indentation. Defaults to `false`.
 
 - `theme="idea|darcula|default"`: Editor IntelliJ IDEA themes.
@@ -214,18 +200,18 @@ Use the following attributes on elements that are converted to editors to adjust
 - `mode="kotlin|js|java|groovy|xml|c|shell|swift|obj-c"`: Different languages styles. Runnable snippets only with `kotlin`. Default to `kotlin`.
 
 - `data-min-compiler-version="1.0.7"`: Minimum target Kotlin [compiler version](https://try.kotlinlang.org/kotlinServer?type=getKotlinVersions)
- 
+
 - `highlight-on-fly="true|false"`: Errors and warnings check for each change in the editor. Defaults to `false`.
 
 - `autocomplete="true|false"`: Get completion on every key press. If `false` => Press ctrl-space to activate autocompletion. Defaults to `false`.
 
-- `indent="4"`: How many spaces a block should be indented. Defaults to `4`. 
+- `indent="4"`: How many spaces a block should be indented. Defaults to `4`.
 
-- `lines="true|false"`: Whether to show line numbers to the left of the editor. Defaults to `false`. 
+- `lines="true|false"`: Whether to show line numbers to the left of the editor. Defaults to `false`.
 
 - `from="5" to="10`: Create a part of code. Example `from` line 5 `to` line 10.
 
-- `data-output-height="200"`: Set the iframe height in `px` in output. Use for target platform `canvas`. 
+- `data-output-height="200"`: Set the iframe height in `px` in output. Use for target platform `canvas`.
 
 - `match-brackets="true|false""`: Determines whether brackets are matched whenever the cursor is moved next to a bracket. Defaults to `false`.
 
@@ -245,4 +231,3 @@ Use the following attributes on elements that are converted to editors to adjust
 2. Install required dependencies `npm install`.
 3. `npm start` to start local development server at http://localhost:9000, or `npm start -- --env.webDemoUrl=http://localhost:6666` if you want a different port.
 4. `npm run build` to create production bundles.
-

--- a/src/config.js
+++ b/src/config.js
@@ -4,20 +4,31 @@ const currentScript = getCurrentScript();
 
 export const RUNTIME_CONFIG = {...getConfigFromElement(currentScript)};
 
-const WEBDEMO_URL = RUNTIME_CONFIG.server || __WEBDEMO_URL__;
-
 /**
  * API Paths
  *
  * @type {{COMPILE: string, COMPLETE: string, VERSIONS: string, JQUERY: string, KOTLIN_JS: string}}
  */
 export const API_URLS = {
-  COMPILE:    `${WEBDEMO_URL}/kotlinServer?type=run&runConf=`,
-  HIGHLIGHT:  `${WEBDEMO_URL}/kotlinServer?type=highlight&runConf=`,
-  COMPLETE:   `${WEBDEMO_URL}/kotlinServer?type=complete&runConf=`,
-  VERSIONS:   `${WEBDEMO_URL}/kotlinServer?type=getKotlinVersions`,
-  JQUERY:     `${WEBDEMO_URL}/static/lib/jquery/dist/jquery.min.js`,
-  KOTLIN_JS:  `${WEBDEMO_URL}/static/kotlin/`
+  server: RUNTIME_CONFIG.server || __WEBDEMO_URL__,
+  get COMPILE() {
+    return `${this.server}/kotlinServer?type=run&runConf=`;
+  },
+  get HIGHLIGHT() {
+    return `${this.server}/kotlinServer?type=highlight&runConf=`;
+  },
+  get COMPLETE() {
+    return `${this.server}/kotlinServer?type=complete&runConf=`;
+  },
+  get VERSIONS() {
+    return `${this.server}/kotlinServer?type=getKotlinVersions`;
+  },
+  get JQUERY() {
+    return `${this.server}/static/lib/jquery/dist/jquery.min.js`;
+  },
+  get KOTLIN_JS() {
+    return `${this.server}/static/kotlin/`;
+  }
 };
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,10 @@
-const WEBDEMO_URL = __WEBDEMO_URL__;
+import {getConfigFromElement, getCurrentScript} from './utils';
+
+const currentScript = getCurrentScript();
+
+export const RUNTIME_CONFIG = {...getConfigFromElement(currentScript)};
+
+const WEBDEMO_URL = RUNTIME_CONFIG.server || __WEBDEMO_URL__;
 
 /**
  * API Paths

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ import {
  * @param {Object} options
  * @return {Promise<Array<ExecutableCode>>}
  */
-// export default function create(selector, eventFunctions, server) {
 export default function create(selector, options = {}) {
   API_URLS.server = options.server || API_URLS.server;
   return ExecutableCode.create(selector, options.eventFunctions);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {RUNTIME_CONFIG} from './config';
+import {RUNTIME_CONFIG, API_URLS} from './config';
 import ExecutableCode from './executable-code';
 import {getConfigFromElement, getCurrentScript, waitForNode} from './utils';
 import {
@@ -17,9 +17,11 @@ import {
  *
  * @param {string} selector
  * @param {Function} eventFunctions
+ * @param {string} server
  * @return {Promise<Array<ExecutableCode>>}
  */
-export default function create(selector, eventFunctions) {
+export default function create(selector, eventFunctions, server) {
+  API_URLS.server = server || API_URLS.server;
   return ExecutableCode.create(selector, eventFunctions);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import {
 } from './discourse-preview-panel-handler';
 
 /**
+ * @typedef {Object} options
+ * @property {Object} eventFunctions
+ * @property {string} server
  *
  * @typedef {Object} eventFunctions
  * @property {Function} onChange
@@ -16,13 +19,13 @@ import {
  * @property {Function} callBack
  *
  * @param {string} selector
- * @param {Function} eventFunctions
- * @param {string} server
+ * @param {Object} options
  * @return {Promise<Array<ExecutableCode>>}
  */
-export default function create(selector, eventFunctions, server) {
-  API_URLS.server = server || API_URLS.server;
-  return ExecutableCode.create(selector, eventFunctions);
+// export default function create(selector, eventFunctions, server) {
+export default function create(selector, options = {}) {
+  API_URLS.server = options.server || API_URLS.server;
+  return ExecutableCode.create(selector, options.eventFunctions);
 }
 
 // Backwards compatibility, should be removed in next major release

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,7 @@ import {
 
 /**
  * @typedef {Object} options
- * @property {Object} eventFunctions
  * @property {string} server
- *
- * @typedef {Object} eventFunctions
  * @property {Function} onChange
  * @property {Function} onTestPassed
  * @property {Function} onConsoleOpen
@@ -24,7 +21,7 @@ import {
  */
 export default function create(selector, options = {}) {
   API_URLS.server = options.server || API_URLS.server;
-  return ExecutableCode.create(selector, options.eventFunctions);
+  return ExecutableCode.create(selector, options);
 }
 
 // Backwards compatibility, should be removed in next major release

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import {RUNTIME_CONFIG} from './config';
 import ExecutableCode from './executable-code';
 import {getConfigFromElement, getCurrentScript, waitForNode} from './utils';
 import {
@@ -36,9 +37,7 @@ create.discourse = function (selector) {
 };
 
 // Auto initialization via data-selector <script> attribute
-const currentScript = getCurrentScript();
-const config = getConfigFromElement(currentScript);
-const {selector, discourseSelector} = config;
+const {selector, discourseSelector} = RUNTIME_CONFIG;
 
 if (selector || discourseSelector) {
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
* Move runtime params read logic to the `config` module, exporting them accordingly.
* Set the default server parameter with preference for one coming through runtime params, if none, the one coming from build params will be set.
* Make `API_URLS` exported object semi-dynamic through the use of getters. With this, what we achieve is the possibility of overwrite it at runtime.
* Add new `server` param as part of an `options` parameter in the main default exported function, and check if that param is being set, when that's the case the `API_URL` config object will be updated with it.
* Update docs with this new feature.

This closes #33 