### PR TITLE
Fix for #28 - Waiting for try.kotlinlang.org

### DIFF
--- a/src/js-executor/index.js
+++ b/src/js-executor/index.js
@@ -67,6 +67,7 @@ class JsExecutor {
     node.appendChild(iframe);
     this.iframe = iframe;
     let iframeDoc = this.iframe.contentDocument || this.iframe.document;
+    iframeDoc.open();
     const kotlinScript = API_URLS.KOTLIN_JS + `${this.kotlinVersion}/kotlin.js`;
     iframeDoc.write("<script src='" + kotlinScript + "'></script>");
     for (let lib of jsLibs) {
@@ -74,6 +75,7 @@ class JsExecutor {
     }
     iframeDoc.write(`<script>${INIT_SCRIPT}</script>`);
     iframe.contentWindow.document.write('<body style="margin: 0; overflow: hidden;"></body>');
+    iframeDoc.close();
     this._initializeKotlin();
   }
 }


### PR DESCRIPTION
Fixes #28.

The important part is to close the document with `document.close()` after writing to it.

The first `write` on a closed document implicitly does an `open()` and resets the document. [[1]](https://developer.mozilla.org/en-US/docs/Web/API/Document/write) To make things more explicit, I also added this call to open.