### PR TITLE
Log uncought JS exceptions to the console

### DIFF
--- a/src/view/output-view.js
+++ b/src/view/output-view.js
@@ -103,6 +103,8 @@ export function getExceptionCauses(exception) {
 }
 
 export function showJsException(exception) {
+  console && console.error(exception);
+
   if (exception.stack != null) {
     let userStackTrace = exception.stack.toString().substr(0, exception.stack.toString().indexOf("at eval (<anonymous>)"));
     return `${UNHANDLED_JS_EXCEPTION}: ${exception.message} \n ${userStackTrace}`;


### PR DESCRIPTION
Errors like #43 were only displayed to the user as "Uncought Javascript Exception:" without any further debug output. Note that this particular exception didn't contain a stacktrace or message. 

When logged to the console, it still contained some useful information for debugging. I see no harm in logging all uncought exceptions in addition to displaying them in a user-friendly way.