### PR TITLE
Fix exception in non-browser environments

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,7 +56,7 @@ export function dashToCamel(string) {
  * @return {Object<string, string>}
  */
 export function getConfigFromElement(element, mergeWithDefaults = false) {
-  if (!element.attributes) {
+  if (!element || !element.attributes) {
     return {};
   }
 


### PR DESCRIPTION
In non-browser environments such as Jest tests there are no `script` tags, so `element` is null