### PR TITLE
Support IE11

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -301,7 +301,7 @@ Look at example:
 </div>
 ```
 
-<button onclick="KotlinPlayground('.kotlin-code-2',{ onChange: (code)=> {console.log(code)}}); this.disabled = true; document.getElementById('kotlin-example').style.display = 'block';">Create</button>
+<button onclick="KotlinPlayground('.kotlin-code-2',{ onChange: function (code) {console.log(code)}}); this.disabled = true; document.getElementById('kotlin-example').style.display = 'block';">Create</button>
 
 <div id="kotlin-example" class="kotlin-code-2" style="display: none;">
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,26 @@ module.exports = (params = {}) => {
           loader: 'babel-loader'
         },
         {
+          test: /\.js$/,
+          include: /node_modules\/escape-string-regexp\//,
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                extends: './.babelrc',
+                presets: [
+                  [
+                    '@babel/preset-env',
+                    {
+                      modules: 'commonjs',
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        },
+        {
           test: /\.monk$/,
           loader: 'monkberry-loader'
         },


### PR DESCRIPTION
Issue: `kotlin-playground` doesn't work in IE11. The reason is `escape-string-regexp` packages which uses an arrow function. I've applied babel to this package