### PR TITLE
Remove listeners when destroying view

### DIFF
--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -546,6 +546,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
     this.jsExecutor = false;
     this.state = null;
     this.codemirror.toTextArea();
+    this.off();
     this.remove();
   }
 }


### PR DESCRIPTION
Sometimes I have to re-initialize kotlin-playground to handle some settings updates. Each time I do that, new event listeners like  https://github.com/JetBrains/kotlin-playground/blob/master/src/executable-code/executable-fragment.js#L59-L61 are added, while old ones are still present on the cached Monkberry instance, which leads to the handler being called more than once

This PR removes all the `monkberry-events` event listeners when the view is destroyed