### PR TITLE
Default Kotlin version on script init support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 ```
 
-You can also overwrite the server where the code will be sent to be compiled and analyzed (for example if you host a server instance that includes your own Kotlin libraries). For that you can set the `data-server` attibute, like this:
+You can also overwrite the server where the code will be sent to be compiled and analyzed (for example if you host a server instance that includes your own Kotlin libraries). For that you can set the `data-server` attribute.
+
+And you can also set a default Kotlin version for code snippets to run on. Bear in mind that the [version set per editor](#customizing-editors) will take precedence though:
 
 ```html
 <script src="https://unpkg.com/kotlin-playground@1"
-        data-selector="code" 
-        data-server="https://my-kotlin-playground-server">
+        data-selector="code"
+        data-server="https://my-kotlin-playground-server"
+        data-version="1.3.41">
 </script>
 ```
 
@@ -74,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ### Options
 
-Kotlin Playground supports several events, and also server URL overwriting passing an additional `options` parameter on initialisation.
+Kotlin Playground supports several events, and also Kotlin version or server URL overwriting passing an additional `options` parameter on initialisation.
 
 For example:
 ```js
@@ -88,6 +91,7 @@ function onTestPassed() {
 
 const options = {
   server: 'https://my-kotlin-playground-server',
+  version: '1.3.41',
   onChange: onChange,
   onTestPassed: onTestPassed,
   callback: callback(targetNode, mountNode)
@@ -101,7 +105,6 @@ playground('.selector', options)
 
 - `onChange(code)` — Fires every time the content of the editor is changed. Debounce time: 0.5s.
  _code_ — current playground code.
-
 
 - `onTestPassed` — Is called after all tests passed. Use for target platform `junit`.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ function onTestPassed() {
 
 const options = {
   server: 'https://my-kotlin-playground-server',
-  onChange: onChange(code),
+  onChange: onChange,
   onTestPassed: onTestPassed,
   callback: callback(targetNode, mountNode)
 };

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -235,10 +235,10 @@ export default class ExecutableCode {
 
   /**
    * @param {string|Node|NodeList} target
-   * @param {Function} eventFunctions
+   * @param {Object} options
    * @return {Promise<Array<ExecutableCode>>}
    */
-  static create(target, eventFunctions) {
+  static create(target, options) {
     let targetNodes;
 
     if (typeof target === 'string') {
@@ -276,6 +276,8 @@ export default class ExecutableCode {
 
           if (listOfVersions.includes(config.version)) {
             compilerVersion = config.version;
+          } else if (listOfVersions.includes(options.version)) {
+            compilerVersion = options.version;
           } else {
             versions.forEach((compilerConfig) => {
               if (compilerConfig.latestStable) {
@@ -290,7 +292,7 @@ export default class ExecutableCode {
               ? versions[versions.length - 1].version
               : latestStableVersion;
           }
-          instances.push(new ExecutableCode(node, {compilerVersion}, eventFunctions));
+          instances.push(new ExecutableCode(node, {compilerVersion}, options));
         } else {
           console.error('Cann\'t get kotlin version from server');
           instances.push(new ExecutableCode(node, {highlightOnly: true}));

--- a/src/index.js
+++ b/src/index.js
@@ -38,23 +38,24 @@ create.default = create;
 /**
  * Initialize Kotlin playground for Discourse platform
  * @param {string} selector
+ * @param {Object} options
  * @return {Promise<Array<ExecutableCode>>}
  */
-create.discourse = function (selector) {
+create.discourse = function (selector, options) {
   discoursePreviewPanelHandler();
-  return create(selector);
+  return create(selector, options);
 };
 
 // Auto initialization via data-selector <script> attribute
-const {selector, discourseSelector} = RUNTIME_CONFIG;
+const {selector, discourseSelector, ...options} = RUNTIME_CONFIG;
 
 if (selector || discourseSelector) {
   document.addEventListener('DOMContentLoaded', () => {
     if (discourseSelector) {
-      create.discourse(discourseSelector);
+      create.discourse(discourseSelector, options);
       waitForNode(DiscourseSelectors.PREVIEW_PANEL, () => discoursePreviewPanelHandler());
     } else {
-      create(selector);
+      create(selector, options);
     }
   });
 }


### PR DESCRIPTION
This PR keeps the same funcitonality regarding Kotlin versions, using the latest stable version in case none is set for a snippet.

But it adds the feature of setting a default version on script initilization, allowing you to initilaly have the whole bunch of snippets on a different version, without the need to be set per code snippet.

In my opinion this could help when using Kotlin Playground with static site generators, or used in combination with other libraries that might target a specific Kotlin version.

Let me know your thoughts on this, thanks!