### PR TITLE
fix: bug replace with more then 2 matches

### DIFF
--- a/src/view/output-view.js
+++ b/src/view/output-view.js
@@ -25,11 +25,11 @@ const BUG_REPORT_MESSAGE = `${ANGLE_BRACKETS_LEFT_HTML}errStream${ANGLE_BRACKETS
 export function processJVMOutput(output, theme) {
   let processedOutput = processingHtmlBrackets(output); // don't need to escape `&`
   return processedOutput
-    .replace(BUG_FLAG, BUG_REPORT_MESSAGE)
-    .replace(`${ANGLE_BRACKETS_LEFT_HTML}outStream${ANGLE_BRACKETS_RIGHT_HTML}`, `<span class="standard-output ${theme}">`)
-    .replace(`${ANGLE_BRACKETS_LEFT_HTML}/outStream${ANGLE_BRACKETS_RIGHT_HTML}`, "</span>")
-    .replace(`${ANGLE_BRACKETS_LEFT_HTML}errStream${ANGLE_BRACKETS_RIGHT_HTML}`, `<span class="error-output ${theme}">`)
-    .replace(`${ANGLE_BRACKETS_LEFT_HTML}/errStream${ANGLE_BRACKETS_RIGHT_HTML}`, "</span>");
+    .split(BUG_FLAG).join(BUG_REPORT_MESSAGE)
+    .split(`${ANGLE_BRACKETS_LEFT_HTML}outStream${ANGLE_BRACKETS_RIGHT_HTML}`).join(`<span class="standard-output ${theme}">`)
+    .split(`${ANGLE_BRACKETS_LEFT_HTML}/outStream${ANGLE_BRACKETS_RIGHT_HTML}`).join("</span>")
+    .split(`${ANGLE_BRACKETS_LEFT_HTML}errStream${ANGLE_BRACKETS_RIGHT_HTML}`).join(`<span class="error-output ${theme}">`)
+    .split(`${ANGLE_BRACKETS_LEFT_HTML}/errStream${ANGLE_BRACKETS_RIGHT_HTML}`).join("</span>");
 }
 
 export function processJUnitResults(data, onTestPassed, onTestFailed) {


### PR DESCRIPTION
For example:

```kotlin
fun main() {
    println("df")
    System.err.print("123")
    println("df")
}
```

<img width="429" alt="Screenshot 2020-02-27 at 16 50 10" src="https://user-images.githubusercontent.com/242514/75451247-3e5a9b00-5981-11ea-9709-f7272fbb19ab.png">
