### PR TITLE
Add brackets after import completion

### DIFF
--- a/src/view/completion-view.js
+++ b/src/view/completion-view.js
@@ -41,20 +41,20 @@ class CompletionView {
    */
   hint(mirror, self, data) {
     if (!this.completion[IMPORT_NAME] || this.completion.hasOtherImports) {
-      this.completeText(mirror)
+      this.completeText(mirror, this.completion.text);
     } else {
-      this.addImport(mirror)
+      this.addImport(mirror);
     }
   }
 
-  completeText(mirror) {
+  completeText(mirror, text) {
     let cur = mirror.getCursor();
     let token = mirror.getTokenAt(cur);
     let from = {line: cur.line, ch: token.start};
     let to = {line: cur.line, ch: token.end};
     const currentSymbol = token.string.trim();
     if ([".", "", "(", ":"].includes(currentSymbol)) {
-      mirror.replaceRange(this.completion.text, to)
+      mirror.replaceRange(text, to)
     } else {
       /*
       Replace string with $ in string in case=>
@@ -67,12 +67,12 @@ class CompletionView {
       let cursorInStringIndex = cur.ch - token.start;
       let sentence$index = currentSymbol.substring(0, cursorInStringIndex).lastIndexOf('$');
       let firstSentence = currentSymbol.substring(0, sentence$index + 1);
-      let completionText = firstSentence + this.completion.text + currentSymbol.substring(cursorInStringIndex, token.string.length);
+      let completionText = firstSentence + text + currentSymbol.substring(cursorInStringIndex, token.string.length);
       mirror.replaceRange(completionText, from, to);
       mirror.setCursor(cur.line, token.start + sentence$index + this.completion.text.length + 1);
       if (completionText.endsWith('(')) {
         mirror.replaceRange(")", {line: cur.line, ch: token.start + this.completion.text.length});
-        mirror.execCommand("goCharLeft")
+        mirror.execCommand("goCharLeft");
       }
     }
   }
@@ -95,6 +95,10 @@ class CompletionView {
       importText += "\n";
     }
     mirror.replaceRange(importText, {line: nextPackageLine, ch: 0});
+
+    let parts = this.completion.text.split('.');
+    let completionText = parts[parts.length - 1];
+    this.completeText(mirror, completionText);
   }
 
   findPackageLineAndFirstImportLine(mirror) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,6 +2539,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"


### PR DESCRIPTION
Example:
```
fun main() {
    val s = sin
}
```
In last version after completion sin:
```
import kotlin.math.sin

fun main() {
   val s = sin
}
```
Now after completion sin:
```
import kotlin.math.sin

fun main() {
   val s = sin()
}
```

