### PR TITLE
KTL-42 JVM chained exceptions are incorrectly rendered in play.kotlinlang.org

### DIFF
--- a/src/executable-code/exception.monk
+++ b/src/executable-code/exception.monk
@@ -13,8 +13,8 @@
 {% endfor %}
 
 {% for cause of causes %}
-    <span class="error-output">Caused by: {{ fullName }}{% if message %}: {{ message }} {% endif %}</span><br/>
-    {% for stacktraceElement of stackTrace %}
+    <span class="error-output">Caused by: {{ cause.fullName }}{% if cause.message %}: {{ cause.message }} {% endif %}</span><br/>
+    {% for stacktraceElement of cause.stackTrace %}
         <span class="stacktrace-element error-output">at {{ stacktraceElement.className }}
           .{{ stacktraceElement.methodName }}({{ stacktraceElement.fileName }}:{{ stacktraceElement.lineNumber }})</span>
         <br/>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-42