### PR TITLE
KTL-649 Playground -  Run JUNIT with an empty state leads to JS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kotlin-playground",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "Self-contained component to embed in websites for running Kotlin code",
   "keywords": [
     "kotlin",

--- a/src/webdemo-api.js
+++ b/src/webdemo-api.js
@@ -99,7 +99,7 @@ export default class WebDemoApi {
             if (data.text) output = processJVMOutput(data.text, theme);
             break;
           case TargetPlatform.JUNIT:
-            data.testResults ? output = processJUnitResults(data.testResults, onTestPassed, onTestFailed) : output = processJVMOutput(data.text, theme);
+            data.testResults ? output = processJUnitResults(data.testResults, onTestPassed, onTestFailed) : output = processJVMOutput(data.text || '', theme);
             break;
         }
       }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-649