### PR TITLE
KTL-1478 Swift Export in Kotlin Playground: support new target in Widget

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -137,6 +137,27 @@ fun main(args: Array<String>) {
 </div>
 
 
+You can try Kotlin export to Swift.
+
+```html
+<div class="kotlin-code" data-target-platform="swift-export"></div>
+```
+<div class="kotlin-code" data-target-platform="swift-export">
+
+```kotlin
+fun mul(a: Int, b: Int): Int {
+    return a * b
+}
+
+fun main(args: Array<String>) {
+    print(mul(-2, 4))
+    println(" + 7 =")
+    print(mul(-2, 4) + 7)
+}
+```
+
+</div>
+
 Use `data-target-platform` attribute with value `junit` for creating examples with tests:
 
 <div class="kotlin-code" data-target-platform="junit">

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,9 @@ export const API_URLS = {
       case TargetPlatforms.JUNIT:
         url = `${this.server}/api/${version}/compiler/test`;
         break;
+      case TargetPlatforms.SWIFT_EXPORT:
+        url = `${this.server}/api/${version}/compiler/translate?compiler=swift-export`;
+        break;
       default:
         console.warn(`Unknown ${platform.id} , used by default JVM`)
         url = `${this.server}/api/${version}/compiler/run`;

--- a/src/executable-code/index.js
+++ b/src/executable-code/index.js
@@ -197,7 +197,7 @@ export default class ExecutableCode {
    */
   getJsLibraries(targetNode, platform) {
     if (isJsRelated(platform)) {
-      if (platform === TargetPlatforms.WASM) {
+      if (platform === TargetPlatforms.WASM || platform === TargetPlatforms.SWIFT_EXPORT) {
         return new Set()
       }
       const jsLibs = targetNode.getAttribute(ATTRIBUTES.JS_LIBS);

--- a/src/js-executor/index.js
+++ b/src/js-executor/index.js
@@ -26,6 +26,9 @@ export default class JsExecutor {
   }
 
   async executeJsCode(jsCode, wasm, jsLibs, platform, outputHeight, theme, onError) {
+    if (platform === TargetPlatforms.SWIFT_EXPORT) {
+      return `<span class="standard-output ${theme}">${jsCode}</span>`;
+    }
     if (platform === TargetPlatforms.CANVAS) {
       this.iframe.style.display = "block";
       if (outputHeight) this.iframe.style.height = `${outputHeight}px`;
@@ -110,7 +113,7 @@ export default class JsExecutor {
       const kotlinScript = API_URLS.KOTLIN_JS + `${normalizeJsVersion(this.kotlinVersion)}/kotlin.js`;
       iframeDoc.write("<script src='" + kotlinScript + "'></script>");
     }
-    if (targetPlatform !== TargetPlatforms.WASM) {
+    if (targetPlatform !== TargetPlatforms.WASM && targetPlatform !== TargetPlatforms.SWIFT_EXPORT) {
       for (let lib of jsLibs) {
         iframeDoc.write("<script src='" + lib + "'></script>");
       }

--- a/src/utils/platforms/TargetPlatforms.ts
+++ b/src/utils/platforms/TargetPlatforms.ts
@@ -7,6 +7,7 @@ export const TargetPlatforms = {
   JAVA: new TargetPlatform('java', 'JVM'),
   JUNIT: new TargetPlatform('junit', 'JUnit'),
   CANVAS: new TargetPlatform('canvas', 'JavaScript(canvas)'),
+  SWIFT_EXPORT: new TargetPlatform('swift-export', 'Swift export'),
 } as const;
 
 export type TargetPlatformsKeys = keyof typeof TargetPlatforms;

--- a/src/utils/platforms/index.ts
+++ b/src/utils/platforms/index.ts
@@ -19,7 +19,8 @@ export function isJsRelated(platform: TargetPlatform) {
     platform === TargetPlatforms.JS ||
     platform === TargetPlatforms.JS_IR ||
     platform === TargetPlatforms.CANVAS ||
-    platform === TargetPlatforms.WASM
+    platform === TargetPlatforms.WASM ||
+    platform === TargetPlatforms.SWIFT_EXPORT
   );
 }
 

--- a/src/webdemo-api.js
+++ b/src/webdemo-api.js
@@ -52,6 +52,7 @@ export default class WebDemoApi {
   static translateKotlinToJs(code, compilerVersion, platform, args, hiddenDependencies) {
     const MINIMAL_VERSION_IR = '1.5.0';
     const MINIMAL_VERSION_WASM = '1.9.0';
+    const MINIMAL_VERSION_SWIFT_EXPORT = '2.0.0';
 
     if (platform === TargetPlatforms.JS_IR && compilerVersion < MINIMAL_VERSION_IR) {
       return Promise.resolve({
@@ -70,6 +71,17 @@ export default class WebDemoApi {
         errors: [{
           severity: "ERROR",
           message: `Wasm compiler backend accessible only since ${MINIMAL_VERSION_WASM} version`
+        }],
+        jsCode: ""
+      })
+    }
+
+    if (platform === TargetPlatforms.SWIFT_EXPORT && compilerVersion < MINIMAL_VERSION_SWIFT_EXPORT) {
+      return Promise.resolve({
+        output: "",
+        errors: [{
+          severity: "ERROR",
+          message: `Swift export accessible only since ${MINIMAL_VERSION_SWIFT_EXPORT} version`
         }],
         jsCode: ""
       })


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1478/Swift-Export-in-Kotlin-Playground-support-new-target-in-Widget