### PR TITLE
Add skiko with version

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -62,11 +62,11 @@ export const API_URLS = {
   get VERSIONS() {
     return `${this.server}/versions`;
   },
-  SKIKO_MJS() {
-    return `${this.composeServer}/api/resource/skiko.mjs`;
+  SKIKO_MJS(version) {
+    return `${this.composeServer}/api/resource/skiko-${version}.mjs`;
   },
-  SKIKO_WASM() {
-    return `${this.composeServer}/api/resource/skiko.wasm`;
+  SKIKO_WASM(version) {
+    return `${this.composeServer}/api/resource/skiko-${version}.wasm`;
   },
   get JQUERY() {
     return `https://cdn.jsdelivr.net/npm/jquery@1/dist/jquery.min.js`;

--- a/src/webdemo-api.js
+++ b/src/webdemo-api.js
@@ -59,7 +59,6 @@ export default class WebDemoApi {
     const MINIMAL_VERSION_IR = '1.5.0';
     const MINIMAL_VERSION_WASM = '1.9.0';
     const MINIMAL_VERSION_SWIFT_EXPORT = '2.0.0';
-    const MAX_VERSION_COMPOSE_EXPORT = '2.0.0';
 
     if (
       platform === TargetPlatforms.JS_IR &&
@@ -84,22 +83,6 @@ export default class WebDemoApi {
           {
             severity: 'ERROR',
             message: `Wasm compiler backend accessible only since ${MINIMAL_VERSION_WASM} version`,
-          },
-        ],
-        jsCode: '',
-      });
-    }
-
-    if (
-      platform === TargetPlatforms.COMPOSE_WASM &&
-      compilerVersion >= MAX_VERSION_COMPOSE_EXPORT
-    ) {
-      return Promise.resolve({
-        output: '',
-        errors: [
-          {
-            severity: 'ERROR',
-            message: `${TargetPlatforms.COMPOSE_WASM.printableName} compiler backend accessible only less ${MAX_VERSION_COMPOSE_EXPORT} version`,
           },
         ],
         jsCode: '',

--- a/tests/utils/screenshots.ts
+++ b/tests/utils/screenshots.ts
@@ -9,8 +9,14 @@ export async function hideCursor(node: Locator, callback: () => Promise<void>) {
   await cursor.evaluate((element) => (element.style.display = null));
 }
 
+const MAX_DIFF_PIXEL_RATIO = 0.01;
+
 export function checkScreenshot(node: Locator, message: string) {
-  return hideCursor(node, () => expect(node, message).toHaveScreenshot());
+  return hideCursor(node, () =>
+    expect(node, message).toHaveScreenshot({
+      maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
+    }),
+  );
 }
 
 export function checkEditorView(editor: Locator, message: string) {
@@ -34,6 +40,9 @@ export function checkEditorView(editor: Locator, message: string) {
       height: boundingBox.height + margins.bottom,
     };
 
-    await expect(editor.page(), message).toHaveScreenshot({ clip });
+    await expect(editor.page(), message).toHaveScreenshot({
+      clip,
+      maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
+    });
   });
 }


### PR DESCRIPTION
No special error for compose wasm, because we have only one compose server

Versioned skiko to invalidate cache on update version