### PR TITLE
Ilgonmic/2 module compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "copy-examples": "node utils/copy-examples",
     "release:ci": "rm -rf dist && npm run build:all && $NPM_TOKEN=%env.NPM_TOKEN% npm publish",
     "start": "webpack-dev-server --port 9002",
-    "start-with-local-compiler": "webpack-dev-server --port 9002 --env webDemoUrl='//localhost:8080'",
+    "start-with-local-compiler": "webpack-dev-server --port 9002 --env webDemoUrl='//localhost:8080' webDemoResourcesUrl='//localhost:8081'",
     "lint": "eslint . --ext .ts",
     "fix": "eslint --fix --ext .ts .",
     "test": "npm run build:all && npm run test:run",

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,10 @@ export const RUNTIME_CONFIG = { ...getConfigFromElement(currentScript) };
 export const API_URLS = {
   server: (RUNTIME_CONFIG.server || __WEBDEMO_URL__).replace(/\/$/, ''),
   composeServer: (
-    __WEBDEMO_URL__
+    __WEBDEMO_URL__ || 'https://compose.sandbox.intellij.net'
+  ).replace(/\/$/, ''),
+  composeResources: (
+    __WEBDEMO_RESOURCES_URL__ || 'https://compose.sandbox.intellij.net'
   ).replace(/\/$/, ''),
 
   COMPILE(platform, version) {
@@ -62,17 +65,23 @@ export const API_URLS = {
   get VERSIONS() {
     return `${this.server}/versions`;
   },
+  SKIKO_VERSION() {
+    return `${this.composeServer}/api/resource/skiko`;
+  },
   SKIKO_MJS(version) {
-    return `${this.composeServer}/api/resource/skiko.mjs`;
+    return `${this.composeResources}/api/resource/skiko-${version}.mjs`;
   },
   SKIKO_WASM(version) {
-    return `${this.composeServer}/api/resource/skiko.wasm`;
+    return `${this.composeResources}/api/resource/skiko-${version}.wasm`;
   },
-  STDLIB_MJS(version) {
-    return `${this.composeServer}/api/resource/stdlib.mjs`;
+  STDLIB_HASH() {
+    return `${this.composeServer}/api/resource/stdlib`;
   },
-  STDLIB_WASM(version) {
-    return `${this.composeServer}/api/resource/stdlib.wasm`;
+  STDLIB_MJS(hash) {
+    return `${this.composeResources}/api/resource/stdlib-${hash}.mjs`;
+  },
+  STDLIB_WASM(hash) {
+    return `${this.composeResources}/api/resource/stdlib-${hash}.wasm`;
   },
   get JQUERY() {
     return `https://cdn.jsdelivr.net/npm/jquery@1/dist/jquery.min.js`;

--- a/src/config.js
+++ b/src/config.js
@@ -62,11 +62,11 @@ export const API_URLS = {
   get VERSIONS() {
     return `${this.server}/versions`;
   },
-  SKIKO_MJS() {
-    return `${this.composeServer}/api/resource/skiko.mjs`;
+  SKIKO_MJS(version) {
+    return `${this.composeServer}/api/resource/skiko-${version}.mjs`;
   },
-  SKIKO_WASM() {
-    return `${this.composeServer}/api/resource/skiko.wasm`;
+  SKIKO_WASM(version) {
+    return `${this.composeServer}/api/resource/skiko-${version}.wasm`;
   },
   get JQUERY() {
     return `https://cdn.jsdelivr.net/npm/jquery@1/dist/jquery.min.js`;

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ export const RUNTIME_CONFIG = { ...getConfigFromElement(currentScript) };
 export const API_URLS = {
   server: (RUNTIME_CONFIG.server || __WEBDEMO_URL__).replace(/\/$/, ''),
   composeServer: (
-    'https://compose.sandbox.intellij.net' || __WEBDEMO_URL__
+    __WEBDEMO_URL__
   ).replace(/\/$/, ''),
 
   COMPILE(platform, version) {
@@ -63,10 +63,16 @@ export const API_URLS = {
     return `${this.server}/versions`;
   },
   SKIKO_MJS(version) {
-    return `${this.composeServer}/api/resource/skiko-${version}.mjs`;
+    return `${this.composeServer}/api/resource/skiko.mjs`;
   },
   SKIKO_WASM(version) {
-    return `${this.composeServer}/api/resource/skiko-${version}.wasm`;
+    return `${this.composeServer}/api/resource/skiko.wasm`;
+  },
+  STDLIB_MJS(version) {
+    return `${this.composeServer}/api/resource/stdlib.mjs`;
+  },
+  STDLIB_WASM(version) {
+    return `${this.composeServer}/api/resource/stdlib.wasm`;
   },
   get JQUERY() {
     return `https://cdn.jsdelivr.net/npm/jquery@1/dist/jquery.min.js`;

--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -413,8 +413,8 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
       );
       const additionalRequests = [];
       if (targetPlatform === TargetPlatforms.COMPOSE_WASM) {
-        if (!this.jsExecutor.skikoImport) {
-          additionalRequests.push(this.jsExecutor.skikoImport);
+        if (this.jsExecutor.stdlibExports) {
+          additionalRequests.push(this.jsExecutor.stdlibExports);
         }
       }
 
@@ -428,7 +428,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
         ),
         ...additionalRequests,
       ]).then(
-        ([state]) => {
+        ([state, ...additionalRequestsResults]) => {
           state.waitingForOutput = false;
           const jsCode = state.jsCode;
           const wasm = state.wasm;
@@ -453,6 +453,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
                 outputHeight,
                 theme,
                 onError,
+                additionalRequestsResults,
               )
               .then((output) => {
                 const originState = state.openConsole;

--- a/src/js-executor/execute-es-module.js
+++ b/src/js-executor/execute-es-module.js
@@ -3,17 +3,16 @@ export async function executeWasmCode(container, jsCode, wasmCode) {
   return execute(container, newCode, wasmCode);
 }
 
-export async function executeWasmCodeWithSkiko(container, jsCode, wasmCode) {
-  const newCode = prepareJsCode(jsCode)
-    .replaceAll(
-      "imports['./skiko.mjs']",
-      "window.skikoImports"
-    );
-  return execute(container, newCode, wasmCode);
+export async function executeWasmCodeWithSkiko(container, jsCode) {
+  return executeJs(container, prepareJsCode(jsCode));
+}
+
+export async function executeWasmCodeWithStdlib(container, jsCode, wasmCode) {
+  return execute(container, prepareJsCode(jsCode), wasmCode);
 }
 
 function execute(container, jsCode, wasmCode) {
-  container.wasmCode = Uint8Array.from(atob(wasmCode), c => c.charCodeAt(0));
+  container.wasmCode = Uint8Array.fromBase64(wasmCode);
   return executeJs(container, jsCode);
 }
 

--- a/src/js-executor/index.js
+++ b/src/js-executor/index.js
@@ -218,7 +218,7 @@ export default class JsExecutor {
               // necessary to load stdlib.wasm before its initialization to parallelize
               // language=JavaScript
               (`const stdlibWasm = fetch('${API_URLS.STDLIB_WASM(hash)}');\n` + script).replace(
-                "new URL('./stdlib.wasm',import.meta.url).href",
+                "fetch(new URL('./stdlib.wasm',import.meta.url).href)",
                 "stdlibWasm"
               ).replace(
                 "(extends) => { return { extends }; }",

--- a/src/webdemo-api.js
+++ b/src/webdemo-api.js
@@ -59,7 +59,6 @@ export default class WebDemoApi {
     const MINIMAL_VERSION_IR = '1.5.0';
     const MINIMAL_VERSION_WASM = '1.9.0';
     const MINIMAL_VERSION_SWIFT_EXPORT = '2.0.0';
-    const MAX_VERSION_COMPOSE_EXPORT = '2.0.0';
 
     if (
       platform === TargetPlatforms.JS_IR &&
@@ -84,22 +83,6 @@ export default class WebDemoApi {
           {
             severity: 'ERROR',
             message: `Wasm compiler backend accessible only since ${MINIMAL_VERSION_WASM} version`,
-          },
-        ],
-        jsCode: '',
-      });
-    }
-
-    if (
-      platform === TargetPlatforms.COMPOSE_WASM &&
-      compilerVersion >= MAX_VERSION_COMPOSE_EXPORT
-    ) {
-      return Promise.resolve({
-        output: '',
-        errors: [
-          {
-            severity: 'ERROR',
-            message: `${TargetPlatforms.COMPOSE_WASM.printableName} compiler backend accessible only less ${MAX_VERSION_COMPOSE_EXPORT} version`,
           },
         ],
         jsCode: '',

--- a/tests/utils/screenshots.ts
+++ b/tests/utils/screenshots.ts
@@ -9,8 +9,14 @@ export async function hideCursor(node: Locator, callback: () => Promise<void>) {
   await cursor.evaluate((element) => (element.style.display = null));
 }
 
+const MAX_DIFF_PIXEL_RATIO = 0.01;
+
 export function checkScreenshot(node: Locator, message: string) {
-  return hideCursor(node, () => expect(node, message).toHaveScreenshot());
+  return hideCursor(node, () =>
+    expect(node, message).toHaveScreenshot({
+      maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
+    }),
+  );
 }
 
 export function checkEditorView(editor: Locator, message: string) {
@@ -34,6 +40,9 @@ export function checkEditorView(editor: Locator, message: string) {
       height: boundingBox.height + margins.bottom,
     };
 
-    await expect(editor.page(), message).toHaveScreenshot({ clip });
+    await expect(editor.page(), message).toHaveScreenshot({
+      clip,
+      maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
+    });
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = (params = {}) => {
   const isServer = process.argv[1].includes('webpack-dev-server');
   const libraryName = 'KotlinPlayground';
   const webDemoUrl = params.webDemoUrl || 'https://api.kotlinlang.org/';
+  const webDemoResourcesUrl = params.webDemoResourcesUrl || 'https://api.kotlinlang.org/';
   const examplesPath = isServer ? '' : 'examples/';
   const pathDist = path.resolve(__dirname, 'dist');
 
@@ -98,6 +99,7 @@ module.exports = (params = {}) => {
 
       new webpack.DefinePlugin({
         __WEBDEMO_URL__: JSON.stringify(webDemoUrl),
+        __WEBDEMO_RESOURCES_URL__: JSON.stringify(webDemoResourcesUrl),
         __IS_PRODUCTION__: isProduction,
         __LIBRARY_NAME__: JSON.stringify(libraryName),
       }),


### PR DESCRIPTION
Now wasm can compile only user code, and libraries are provided statically.
So server can return versions of skiko and stdlib (for stdlib hash is used). Then based on these "versions" playground has to get static files from static server, versions are necessary for caching.
The all wasm files are instantiated correctly