### PR TITLE
add feature cmd-/ to toggleComment in code

### DIFF
--- a/src/executable-code/executable-fragment.js
+++ b/src/executable-code/executable-fragment.js
@@ -787,6 +787,7 @@ export default class ExecutableFragment extends ExecutableCodeTemplate {
         'Cmd-Alt-L': 'indentAuto',
         'Shift-Tab': 'indentLess',
         'Ctrl-/': 'toggleComment',
+        'Cmd-/': 'toggleComment',
         'Cmd-[': false,
         'Cmd-]': false,
         'Ctrl-Space': 'autocomplete',


### PR DESCRIPTION
fix #237  , 

I was using the kotlin playground website [here](https://play.kotlinlang.org/), felt like it will be more intuitive to have cmd-/ to toggle comment, so I am trying to get it as a feature.