### PR TITLE
feat(completions): Add LSP, WebSocket-based autocompletion logic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -60,6 +60,10 @@ export const API_URLS = {
   COMPLETE(version) {
     return `${this.server}/api/${version}/compiler/complete`;
   },
+  // TODO(KTL-3773): support multiple Kotlin versions with LSP-based completions
+  COMPLETE_WEBSOCKET(/* version */) {
+    return `ws://${this.server}/api/complete`;
+  },
   get VERSIONS() {
     return `${this.server}/versions`;
   },

--- a/src/utils/websockets/webSocketConnection.js
+++ b/src/utils/websockets/webSocketConnection.js
@@ -1,0 +1,155 @@
+import { API_URLS } from '../../config';
+
+const WS_COMPLETIONS_TIMEOUT_DURATION = 10_000;
+const MAX_RECONNECT_RETRIES = 5;
+
+const ConnectionState = {
+  DISCONNECTED: 'disconnected',
+  CONNECTED: 'connected',
+  CONNECTING: 'connecting',
+};
+
+const state = {
+  connection: null,
+  connectionState: ConnectionState.DISCONNECTED,
+  retryAttempt: 0,
+};
+
+const pendingRequest = new Map();
+let nextId = 1;
+let queuedRequest = null;
+
+export function completionCallback(callback, project, line, ch) {
+  const id = String(nextId++);
+
+  const timeout = setTimeout(() => {
+    pendingRequest.delete(id);
+    callback([]);
+  }, WS_COMPLETIONS_TIMEOUT_DURATION);
+
+  pendingRequest.set(id, { callback, timeout });
+
+  const files = project['files'];
+
+  const message = {
+    requestId: id,
+    completionRequest: { files },
+    line,
+    ch,
+  };
+
+  if (isConnectionReady()) {
+    safeSend(state.connection, message);
+    try {
+      state.connection.send(JSON.stringify(message));
+    } catch (error) {
+      queuedRequest = message;
+      handleDisconnect();
+    }
+  } else {
+    queuedRequest = message;
+    connect();
+  }
+}
+
+function connect() {
+  if (
+    isConnectionReady() ||
+    state.connectionState === ConnectionState.CONNECTING
+  ) {
+    return;
+  }
+
+  state.connectionState = ConnectionState.CONNECTING;
+
+  try {
+    const ws = new WebSocket(API_URLS.COMPLETE_WEBSOCKET());
+    state.connection = ws;
+
+    ws.onopen = () => {
+      state.connectionState = ConnectionState.CONNECTED;
+      state.retryAttempt = 0;
+
+      if (queuedRequest) safeSend(ws, queuedRequest);
+    };
+
+    ws.onmessage = handleMessage;
+
+    ws.onerror = () => {
+      handleDisconnect(true);
+    };
+
+    ws.onclose = (event) => {
+      const tryReconnect = event.code !== 1000;
+      handleDisconnect(tryReconnect);
+    };
+  } catch {
+    handleDisconnect(true);
+  }
+  return true;
+}
+
+function handleMessage(msg) {
+  let payload;
+  try {
+    payload = JSON.parse(msg.data);
+  } catch {
+    return;
+  }
+
+  if (payload.requestId) {
+    const entry = pendingRequest.get(payload.requestId);
+    if (!entry) return;
+
+    clearTimeout(entry.timeout);
+    pendingRequest.delete(payload.requestId);
+
+    if (payload.completions) {
+      entry.callback(payload.completions);
+    } else {
+      console.error(payload.message);
+      entry.callback([]);
+    }
+  }
+}
+
+function handleDisconnect(tryReconnect) {
+  if (isConnectionReady()) return;
+  state.connectionState = ConnectionState.DISCONNECTED;
+  pendingRequest.forEach((_, entry) => {
+    entry.callback([]);
+    clearTimeout(entry.timeout);
+  });
+
+  if (tryReconnect && state.retryAttempt <= MAX_RECONNECT_RETRIES) {
+    state.retryAttempt++;
+    connect();
+  } else {
+    try {
+      state.connection.close();
+    } finally {
+      state.connection = null;
+      state.retryAttempt = 0;
+    }
+  }
+}
+
+function safeSend(ws, message) {
+  try {
+    ws.send(JSON.stringify(message));
+    if (queuedRequest && queuedRequest.requestId === message.requestId)
+      queuedRequest = null;
+  } catch (err) {
+    console.warn(`Failed to send ${message}: `, err);
+    queuedRequest = message;
+    handleDisconnect(true);
+  }
+}
+
+function isConnectionReady() {
+  return (
+    state.connection &&
+    state.connectionState === ConnectionState.CONNECTED &&
+    state.connection.readyState === WebSocket.OPEN
+  );
+}


### PR DESCRIPTION
This PR introduces an alternative way to retrieve autocompletions from *compiler server* through WebSocket (see [KTL-2807](https://youtrack.jetbrains.com/issue/KTL-2807) and [JetBrains/kotlin-compiler-server#878](https://github.com/JetBrains/kotlin-compiler-server/pull/878)).

> Note: This feature will be **disabled** by default as by now it is just an alternative and experimental.

The completion retrieval implementation is backed by the built-in [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) API. 

The *protcol* between the server and the client consists of 3 kind of *frames*:
- `init` sent on connection, responses will look like `Init { sessionId: string, requestId: string? }`
- Completion requests are triggered from the client specifying a `requestId` (a random `UUID`) with:
```json
{
  "requestId": "string",
  "completionRequest": {
    "files": [
      {
        "name": "string",
        "text": "string"
      }
    ]
  },
  "line": "int",
  "ch": "int"
}
```
- For each completion request a client could either get one of the following frames:
  - `Error: { requestId: string?, message: string }` in case an error occurred (note: `requestId` might be empty for errors like a malformed request).
  - `Discarded: { requestId: string? }` sent as a backpressure mechanism: it informs the client that the request with the associated `requestId` has been dropped in favor of a more recent request from the same client for the same document.
  - A **completion** result as follows:
```json
{
  "requestId": "string",
  "completions": [
    {
      "text": "string",
      "displayText": "string",
      "tail": "string?",
      "import": "string?",
      "icon": "Icon?",
      "hasOtherImport": "boolean?"
    }
  ]
}
```