### PR TITLE
KTL-3886 Kotlin Playground: Invalid URL error in when using WASM with Kotlin 2.3.0-RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kotlin-playground",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Self-contained component to embed in websites for running Kotlin code",
   "keywords": [
     "kotlin",

--- a/src/js-executor/execute-es-module.js
+++ b/src/js-executor/execute-es-module.js
@@ -35,7 +35,7 @@ function prepareJsCode(jsCode) {
         "instantiate(window.wasmCode, importObject)).instance;\nwindow.wasmCode = undefined;"
       )
       .replace(
-        "instantiateStreaming(fetch(new URL('./playground.wasm',import.meta.url).href), importObject)).instance;",
+        /instantiateStreaming\(fetch\(new URL\('\.\/playground\.wasm',import\.meta\.url\)\.href\),\s?importObject(?:,\s?\{ builtins:\s?\[''\]\s?\})?\)\)\.instance;/,
         "instantiate(window.wasmCode, importObject)).instance;\nwindow.wasmCode = undefined;"
       )
       .replace(


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-3886/Kotlin-Playground-Invalid-URL-error-in-when-using-WASM-with-Kotlin-2.3.0-RC

The problem was caused by a new part in the string: `, { builtins: ['']} `.
Changed the matching rules to fix this.

Checked with 2.3.0-RC and the stable versions:
<img width="1035" height="408" alt="Screenshot 2025-11-25 at 16 35 51" src="https://github.com/user-attachments/assets/fb40944a-152c-4854-baf0-c2d681188494" />

<img width="1043" height="433" alt="Screenshot 2025-11-25 at 16 35 08" src="https://github.com/user-attachments/assets/d7ad16ee-8be6-4ac7-bd26-98c46f89d973" />

